### PR TITLE
added `value_last` and `datetime_last` to sensor column in `locations_view`

### DIFF
--- a/openaqdb/locations/locations.sql
+++ b/openaqdb/locations/locations.sql
@@ -74,6 +74,8 @@ WITH nodes_instruments AS (
         'id', m.measurands_id
         , 'name', m.measurand
         , 'units', m.units
+        , 'value_last', sl.value_latest
+        , 'datetime_last', sl.datetime_last
         , 'display_name', m.display
         )
     )) as sensors


### PR DESCRIPTION
For each parameter object in the sensors column, there will be `value_last` and `datetime_last` that we will be able to add to the `v3/locations` objects, via `locations_view_cached`