### PR TITLE
Added to deal with sensor_nodes that are not within a boundary

### DIFF
--- a/openaqdb/tables/countries_views.sql
+++ b/openaqdb/tables/countries_views.sql
@@ -7,6 +7,15 @@ RETURNS int LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE AS $$
 SELECT countries_id from countries WHERE st_intersects(g::geography, geog) LIMIT 1;
 $$;
 
+CREATE OR REPLACE FUNCTION get_closest_countries_id(g geometry, w int DEFAULT 1000)
+  RETURNS int LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT c.countries_id
+    FROM countries c
+    WHERE ST_DWithin(c.geog, g::geography, w)
+    ORDER BY ST_Distance(c.geog, g::geography) ASC
+    LIMIT 1;
+ $$;
+
 CREATE OR REPLACE FUNCTION country(g geography)
 RETURNS text LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE AS $$
 SELECT iso from countries WHERE st_intersects(g, geog) LIMIT 1;


### PR DESCRIPTION
A pretty simple solution that is reasonably fast. The following query took ~1s
```sql
SELECT sensor_nodes_id
, timezones_id
, st_x(geom)
, st_y(geom)
, get_countries_id(geom)
, get_closest_countries_id(geom) 
FROM sensor_nodes 
WHERE countries_id IS NULL 
AND geom IS NOT NULL 
ORDER BY added_on ASC 
LIMIT 10;

 sensor_nodes_id | timezones_id |        st_x         |        st_y        | get_countries_id | get_closest_countries_id 
-----------------+--------------+---------------------+--------------------+------------------+--------------------------
            9339 |          230 |           55.309166 |           25.25848 |                  |                       59
            2997 |          369 |  16.449341666505767 | 43.510652777575096 |                  |                      103
           10849 |          346 |          8.02377464 |        58.16232369 |                  |                       53
            3524 |          338 |  -4.734420999811524 |   55.9440789996131 |                  |                       79
           10738 |          346 |             6.15682 |           62.47217 |                  |                         
           10562 |          346 |            9.695568 |          59.057304 |                  |                       53
            5176 |          325 |  12.571099999898298 |  55.67429999969188 |                  |                       71
           10512 |          297 | -18.088205000320293 |  65.68409199986785 |                  |                      192
           10899 |          427 |            72.52048 |           19.13276 |                  |                         
            4024 |          140 |  -61.04120599975462 |  14.60349699987772 |                  |                       22
(10 rows)
```